### PR TITLE
Add static methods

### DIFF
--- a/com/craftinginterpreters/lox/Interpreter.java
+++ b/com/craftinginterpreters/lox/Interpreter.java
@@ -10,6 +10,7 @@ class Interpreter implements Expr.Visitor<Object>, Stmt.Visitor<Void> {
     final Environment globals = new Environment();
     private Environment environment = globals;
     private final Map<Expr, Integer> locals = new HashMap<>();
+    private static final LoxClass metaclass = new LoxClass("Class", new HashMap<String, LoxFunction>());
 
     Interpreter() {
         globals.define("clock", new LoxCallable() {

--- a/com/craftinginterpreters/lox/Interpreter.java
+++ b/com/craftinginterpreters/lox/Interpreter.java
@@ -10,7 +10,6 @@ class Interpreter implements Expr.Visitor<Object>, Stmt.Visitor<Void> {
     final Environment globals = new Environment();
     private Environment environment = globals;
     private final Map<Expr, Integer> locals = new HashMap<>();
-    private static final LoxClass metaclass = new LoxClass("Class", new HashMap<String, LoxFunction>());
 
     Interpreter() {
         globals.define("clock", new LoxCallable() {

--- a/com/craftinginterpreters/lox/Interpreter.java
+++ b/com/craftinginterpreters/lox/Interpreter.java
@@ -8,6 +8,7 @@ import java.util.Map;
 class Interpreter implements Expr.Visitor<Object>, Stmt.Visitor<Void> {
 
     final Environment globals = new Environment();
+    static final LoxClass metaclass = new LoxClass();
     private Environment environment = globals;
     private final Map<Expr, Integer> locals = new HashMap<>();
 
@@ -28,6 +29,8 @@ class Interpreter implements Expr.Visitor<Object>, Stmt.Visitor<Void> {
                 return "<native fn>";
             }
         });
+
+        globals.define("Class", metaclass);
     }
 
     @Override

--- a/com/craftinginterpreters/lox/Interpreter.java
+++ b/com/craftinginterpreters/lox/Interpreter.java
@@ -247,7 +247,11 @@ class Interpreter implements Expr.Visitor<Object>, Stmt.Visitor<Void> {
 
         Map<String, LoxFunction> methods = new HashMap<>();
         for (Stmt.Function method : stmt.methods) {
-            LoxFunction function = new LoxFunction(method, environment, method.name.lexeme.equals("init"));
+            LoxFunction function = new LoxFunction(
+                method,
+                environment,
+                method.name.lexeme.equals("init")
+            );
             methods.put(method.name.lexeme, function);
         }
 

--- a/com/craftinginterpreters/lox/Interpreter.java
+++ b/com/craftinginterpreters/lox/Interpreter.java
@@ -259,6 +259,21 @@ class Interpreter implements Expr.Visitor<Object>, Stmt.Visitor<Void> {
         }
 
         LoxClass klass = new LoxClass(stmt.name.lexeme, methods);
+
+        LoxClass metaclass = klass.getLoxClass();
+        for (Stmt.Function staticMethod : stmt.staticMethods) {
+            LoxFunction function = new LoxFunction(
+                staticMethod,
+                environment,
+                false
+            );
+
+            metaclass.addMethod(
+                staticMethod.name.lexeme,
+                function
+            );
+        }
+
         environment.assign(stmt.name, klass);
         return null;
     }

--- a/com/craftinginterpreters/lox/LoxClass.java
+++ b/com/craftinginterpreters/lox/LoxClass.java
@@ -33,6 +33,10 @@ class LoxClass extends LoxInstance implements LoxCallable {
         return null;
     }
 
+    public void addMethod(String name, LoxFunction function) {
+        methods.put(name, function);
+    }
+
     @Override
     public Object call(Interpreter interpreter, List<Object> arguments) {
         LoxInstance instance = new LoxInstance(this);

--- a/com/craftinginterpreters/lox/LoxClass.java
+++ b/com/craftinginterpreters/lox/LoxClass.java
@@ -8,9 +8,6 @@ class LoxClass extends LoxInstance implements LoxCallable {
     private final Map<String, LoxFunction> methods;
 
     LoxClass(String name, Map<String, LoxFunction> methods) {
-        // I need a class for the LoxInstance constructor
-        // That's going to be the metaclass for this class
-        super(new LoxClass(name + "Metaclass")); // This would end up being an infinite loop
         this.name = name;
         this.methods = methods;
     }

--- a/com/craftinginterpreters/lox/LoxClass.java
+++ b/com/craftinginterpreters/lox/LoxClass.java
@@ -7,12 +7,22 @@ import java.util.HashMap;
 class LoxClass extends LoxInstance implements LoxCallable {
     final String name;
     private final Map<String, LoxFunction> methods;
-    private static final LoxClass metaclass = new LoxClass("Class", new HashMap<String, LoxFunction>());
 
     LoxClass(String name, Map<String, LoxFunction> methods) {
-        super(metaclass);
+        super(new LoxClass(name + "Metaclass", new HashMap<String, LoxFunction>(), Interpreter.metaclass));
         this.name = name;
         this.methods = methods;
+    }
+
+    LoxClass(String name, Map<String, LoxFunction> methods, LoxClass klass) {
+        super(klass);
+        this.name = name;
+        this.methods = methods;
+    }
+
+    LoxClass() {
+        this.name = "Class";
+        this.methods = new HashMap<String, LoxFunction>();
     }
 
     LoxFunction findMethod(String name) {

--- a/com/craftinginterpreters/lox/LoxClass.java
+++ b/com/craftinginterpreters/lox/LoxClass.java
@@ -2,12 +2,15 @@ package com.craftinginterpreters.lox;
 
 import java.util.List;
 import java.util.Map;
+import java.util.HashMap;
 
 class LoxClass extends LoxInstance implements LoxCallable {
     final String name;
     private final Map<String, LoxFunction> methods;
+    private static final LoxClass metaclass = new LoxClass("Class", new HashMap<String, LoxFunction>());
 
     LoxClass(String name, Map<String, LoxFunction> methods) {
+        super(metaclass);
         this.name = name;
         this.methods = methods;
     }

--- a/com/craftinginterpreters/lox/LoxClass.java
+++ b/com/craftinginterpreters/lox/LoxClass.java
@@ -3,7 +3,7 @@ package com.craftinginterpreters.lox;
 import java.util.List;
 import java.util.Map;
 
-class LoxClass implements LoxCallable {
+class LoxClass extends LoxInstance implements LoxCallable {
     final String name;
     private final Map<String, LoxFunction> methods;
 

--- a/com/craftinginterpreters/lox/LoxClass.java
+++ b/com/craftinginterpreters/lox/LoxClass.java
@@ -8,6 +8,9 @@ class LoxClass extends LoxInstance implements LoxCallable {
     private final Map<String, LoxFunction> methods;
 
     LoxClass(String name, Map<String, LoxFunction> methods) {
+        // I need a class for the LoxInstance constructor
+        // That's going to be the metaclass for this class
+        super(new LoxClass(name + "Metaclass")); // This would end up being an infinite loop
         this.name = name;
         this.methods = methods;
     }

--- a/com/craftinginterpreters/lox/LoxInstance.java
+++ b/com/craftinginterpreters/lox/LoxInstance.java
@@ -14,6 +14,8 @@ class LoxInstance {
     }
 
     LoxInstance() {
+        System.out.println("lol");
+        System.out.println(this);
         if (this instanceof LoxClass) this.klass = (LoxClass)this;
         addMethods();
     }

--- a/com/craftinginterpreters/lox/LoxInstance.java
+++ b/com/craftinginterpreters/lox/LoxInstance.java
@@ -10,12 +10,12 @@ class LoxInstance {
 
     LoxInstance(LoxClass klass) {
         this.klass = klass;
-        addMethods();
+        addSharedMethods();
     }
 
     LoxInstance() {
         if (this instanceof LoxClass) this.klass = (LoxClass)this;
-        addMethods();
+        addSharedMethods();
     }
 
     LoxClass getLoxClass() {
@@ -37,7 +37,7 @@ class LoxInstance {
         fields.put(name.lexeme, value);
     }
 
-    void addMethods() {
+    void addSharedMethods() {
         this.fields.put("klass", new LoxCallable() {
             @Override
             public int arity() {

--- a/com/craftinginterpreters/lox/LoxInstance.java
+++ b/com/craftinginterpreters/lox/LoxInstance.java
@@ -18,6 +18,10 @@ class LoxInstance {
         addMethods();
     }
 
+    LoxClass getLoxClass() {
+        return klass;
+    }
+
     Object get(Token name) {
         if (fields.containsKey(name.lexeme)) {
             return fields.get(name.lexeme);

--- a/com/craftinginterpreters/lox/LoxInstance.java
+++ b/com/craftinginterpreters/lox/LoxInstance.java
@@ -14,8 +14,6 @@ class LoxInstance {
     }
 
     LoxInstance() {
-        System.out.println("lol");
-        System.out.println(this);
         if (this instanceof LoxClass) this.klass = (LoxClass)this;
         addMethods();
     }

--- a/com/craftinginterpreters/lox/LoxInstance.java
+++ b/com/craftinginterpreters/lox/LoxInstance.java
@@ -11,6 +11,10 @@ class LoxInstance {
         this.klass = klass;
     }
 
+    LoxInstance() {
+        if (this instanceof LoxClass) this.klass = (LoxClass)this;
+    }
+
     Object get(Token name) {
         if (fields.containsKey(name.lexeme)) {
             return fields.get(name.lexeme);

--- a/com/craftinginterpreters/lox/LoxInstance.java
+++ b/com/craftinginterpreters/lox/LoxInstance.java
@@ -2,6 +2,7 @@ package com.craftinginterpreters.lox;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.List;
 
 class LoxInstance {
     private LoxClass klass;
@@ -9,10 +10,12 @@ class LoxInstance {
 
     LoxInstance(LoxClass klass) {
         this.klass = klass;
+        addMethods();
     }
 
     LoxInstance() {
         if (this instanceof LoxClass) this.klass = (LoxClass)this;
+        addMethods();
     }
 
     Object get(Token name) {
@@ -28,6 +31,25 @@ class LoxInstance {
 
     void set(Token name, Object value) {
         fields.put(name.lexeme, value);
+    }
+
+    void addMethods() {
+        this.fields.put("klass", new LoxCallable() {
+            @Override
+            public int arity() {
+                return 0;
+            }
+
+            @Override
+            public Object call(Interpreter interpreter, List<Object> arguments) {
+                return LoxInstance.this.klass;
+            }
+
+            @Override
+            public String toString() {
+                return "<native fn>";
+            }
+        });
     }
 
     @Override

--- a/com/craftinginterpreters/lox/Parser.java
+++ b/com/craftinginterpreters/lox/Parser.java
@@ -54,13 +54,18 @@ class Parser {
         consume(LEFT_BRACE, "Expect '{' before class body.");
 
         List<Stmt.Function> methods = new ArrayList<>();
+        List<Stmt.Function> staticMethods = new ArrayList<>();
         while (!check(RIGHT_BRACE) && !isAtEnd()) {
-            methods.add(function("method"));
+            if (match(CLASS)) {
+                staticMethods.add(function("static method"));
+            } else {
+                methods.add(function("method"));
+            }
         }
 
         consume(RIGHT_BRACE, "Expect '}' after class body.");
 
-        return new Stmt.Class(name, methods);
+        return new Stmt.Class(name, methods, staticMethods);
     }
 
     private Stmt.Function function(String kind) {

--- a/com/craftinginterpreters/lox/Stmt.java
+++ b/com/craftinginterpreters/lox/Stmt.java
@@ -28,9 +28,10 @@ abstract class Stmt {
     }
 
     static class Class extends Stmt {
-        Class(Token name, List<Stmt.Function> methods) {
+        Class(Token name, List<Stmt.Function> methods, List<Stmt.Function> staticMethods) {
             this.name = name;
             this.methods = methods;
+            this.staticMethods = staticMethods;
         }
 
         @Override
@@ -39,6 +40,7 @@ abstract class Stmt {
         }
         final Token name;
         final List<Stmt.Function> methods;
+        final List<Stmt.Function> staticMethods;
     }
 
     static class Expression extends Stmt {

--- a/com/craftinginterpreters/tool/GenerateAst.java
+++ b/com/craftinginterpreters/tool/GenerateAst.java
@@ -31,7 +31,7 @@ public class GenerateAst {
 
         defineAst(outputDir, "Stmt", Arrays.asList(
                 "Block : List<Stmt> statements",
-                "Class : Token name, List<Stmt.Function> methods",
+                "Class : Token name, List<Stmt.Function> methods, List<Stmt.Function> staticMethods",
                 "Expression : Expr expression",
                 "Function : Token name, List<Token> params, List<Stmt> body",
                 "Print : Expr expression",


### PR DESCRIPTION
Following the Smalltalk implementation of class methods through metaclasses here. When a class is created, we automatically create a Metaclass for it where static (class) methods will reside. This keeps method lookup consistent on objects regardless of whether that object is a class itself or an instance of a class.

![smalltalk_metaclass](https://github.com/user-attachments/assets/4188ea5d-b8dc-4cd6-9653-0609c25b7797)